### PR TITLE
Allow environment variable to set the TODO file

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,22 @@ To search through todos just start typing
 Use up/down arrows or start typing to select the TODO you want to mark as done, then press Enter.
 
 
- **Note:**  todos will be saved to a text file located at `~/.rofi_todos`.
+## Change save file
+
+To change to location of the save file, and also the file which will be searched for the todos you
+can set the environment variable `TODO_FILE`:
+
+```
+export TODO_FILE=~/.other_todo_file
+```
+
+or in a direct shell execution:
+
+```
+$ TODO_FILE=~/.other_todo_file rofi -modi TODO:/path/to/rofi-todo/rofi-todo.sh -show TODO
+```
+
+ **Note:**  By default todos will be saved to a text file located at `~/.rofi_todos`.
 
 ### Save a copy of completed TODOs
 

--- a/rofi-todo.sh
+++ b/rofi-todo.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-TODO_FILE=~/.rofi_todos
+# Set default todo file
+if [ -z ${TODO_FILE+x} ]; then
+    TODO_FILE=~/.rofi_todos
+fi
 
 if [[ ! -a "${TODO_FILE}" ]]; then
     touch "${TODO_FILE}"


### PR DESCRIPTION
I wanted the ability to add more todo files, for example if you have multiple categories of todo files (or "lists" which you could have in most other programs).

It should not affect previous installs, except if the env var `TODO_FILE` is set and different than `~/.rofi_todos`.